### PR TITLE
Sync grammar's base scope with other grammar packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
 # Ballerina plugin for Sublime Text 3
 
-## What is Ballerina
+## What is Ballerina?
 
-ballerina is a general purpose, concurrent and strongly typed
+Ballerina is a general purpose, concurrent and strongly typed
 programming language with both textual and graphical syntaxes.
 
-for more info: http://ballerinalang.org/
+For more info, visit http://ballerinalang.org/
 
-##To install the plugin on Linux
+## To install the plugin on Linux
 
-1. Go to home directory & locate .config/sublime-text-3/Packages folder
-2. place extracted zip content to packages folder
-3. Start the sublime-text
+1. Go to home directory & locate `.config/sublime-text-3/Packages` folder
+2. Place extracted zip content to packages folder
+3. Start Sublime Text
 
-##To install the plugin on MacOS
+## To install the plugin on macOS
 
-1. Go to home directory & locate /Users/<UserName>/Library/Application Support/Sublime Text 3/Packages folder
-2. place extracted zip content to packages folder
-3. Start the sublime-text
+1. Go to home directory & locate `/Users/<UserName>/Library/Application Support/Sublime Text 3/Packages` folder
+2. Place extracted zip content to packages folder
+3. Start Sublime Text
 
-Note: If package path doesn't exist click on  "Preferences -> Browse Packages". This will open your package installation path
+Note: If package path doesn't exist, click on "Preferences -> Browse Packages".
+This will open your package installation path.
 
-##How to contribute
+## How to contribute
 
 Pull requests are highly encouraged and we recommend you to create a GitHub issue
 to discuss the issue or feature that you are contributing to.
 
-##License
+## License
 
 Ballerina Sublime Text 3 plugin source is available under the Apache 2.0 License.
 
-##Copyright
+## Copyright
 
 Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.

--- a/ballerina.sublime-syntax
+++ b/ballerina.sublime-syntax
@@ -3,7 +3,7 @@
 # See http://www.sublimetext.com/docs/3/syntax.html
 file_extensions:
   - bal
-scope: source.bal
+scope: source.ballerina
 name: Ballerina
 contexts:
   main:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Ballerina",
   "version": "0.8.0",
-  "description": "syntax highlighting support for ballerinalang http://ballerinalang.org/",
+  "description": "Syntax highlighting support for ballerinalang http://ballerinalang.org/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ballerinalang/plugin-sublimetext3.git"


### PR DESCRIPTION
See [`ballerinalang/plugin-atom#17`](https://github.com/ballerinalang/plugin-atom/pull/17) and [`ballerinalang/plugin-vscode#3`](https://github.com/ballerinalang/plugin-vscode/pull/3). This PR is essentially doing for Sublime Text what my earlier PR is doing for Atom. Note that I'm a user of the latter editor, not the former: I can't test my changes in Sublime, but I'd be surprised if they broke anything.

I also took a moment to fix some glaring syntax errors in the repository's readme file, along with minor improvements to punctuation and formatting. I deliberately steered clear of changing the wording of the text, but you should know that "home directory" can be shortened with tilde expansion instead:

~~~diff
 macOS:
-/Users/<UserName>/Library/Application Support/Sublime Text 3/Packages
+~/Library/Application Support/Sublime Text 3/Packages
 
 Linux:
+~/.config/sublime-text-3/Packages
~~~

Virtually every user of a Unix-like operating system will (or *should*) know what this means. =)